### PR TITLE
Change AddHandler call to pass a delegate

### DIFF
--- a/blog/restsharp_custom_json_serializer.md
+++ b/blog/restsharp_custom_json_serializer.md
@@ -130,11 +130,11 @@ private RestClient CreateClient(string baseUrl)
     var client = new RestClient(baseUrl);
 
     // Override with Newtonsoft JSON Handler
-    client.AddHandler("application/json", NewtonsoftJsonSerializer.Default);
-    client.AddHandler("text/json", NewtonsoftJsonSerializer.Default);
-    client.AddHandler("text/x-json", NewtonsoftJsonSerializer.Default);
-    client.AddHandler("text/javascript", NewtonsoftJsonSerializer.Default);
-    client.AddHandler("*+json", NewtonsoftJsonSerializer.Default);
+    client.AddHandler("application/json", () => NewtonsoftJsonSerializer.Default);
+    client.AddHandler("text/json", () => NewtonsoftJsonSerializer.Default);
+    client.AddHandler("text/x-json", () => NewtonsoftJsonSerializer.Default);
+    client.AddHandler("text/javascript", () => NewtonsoftJsonSerializer.Default);
+    client.AddHandler("*+json", () => NewtonsoftJsonSerializer.Default);
 
     return client;
 }


### PR DESCRIPTION
RestSharp has changed the AddHandler method, marking the old way as Obsolete.